### PR TITLE
feat: bump `MongoDb.Driver` to `2.28.0`

### DIFF
--- a/Rebus.MongoDb/Rebus.MongoDb.csproj
+++ b/Rebus.MongoDb/Rebus.MongoDb.csproj
@@ -24,8 +24,8 @@
 		<None Include="icon.png" Pack="true" PackagePath="" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="mongodb.driver" Version="2.22.0" />
-		<PackageReference Include="MongoDB.Driver.GridFS" Version="2.22.0" />
+		<PackageReference Include="mongodb.driver" Version="2.28.0" />
+		<PackageReference Include="MongoDB.Driver.GridFS" Version="2.28.0" />
 		<PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
 		<PackageReference Include="rebus" Version="8.0.1" />
 	</ItemGroup>


### PR DESCRIPTION
Starting from 2.28.0 it's using a strong named assembly, so a bump is needed for any who wants to run with >= 2.28.0

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
