### PR TITLE
feat: update MongoDB.Driver to 3.0.0

### DIFF
--- a/Rebus.MongoDb.Tests/Bugs/CanFollowGuidRepresentation.cs
+++ b/Rebus.MongoDb.Tests/Bugs/CanFollowGuidRepresentation.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using NUnit.Framework;
+using Rebus.Logging;
+using Rebus.MongoDb.Sagas;
+using Rebus.Sagas;
+using Rebus.Tests.Contracts;
+
+namespace Rebus.MongoDb.Tests.Bugs;
+
+[TestFixture]
+public class CanFollowGuidRepresentation : FixtureBase
+{
+    static readonly IEnumerable<ISagaCorrelationProperty> None = Enumerable.Empty<ISagaCorrelationProperty>();
+    MongoDbSagaStorage _sagaStorage;
+
+    [OneTimeSetUp]
+    protected void Init()
+    {
+        BsonClassMap.RegisterClassMap<MyGuidRepresentationSagaData>(map =>
+        {
+            map.MapMember(obj => obj.StandardId)
+                .SetSerializer(new GuidSerializer(GuidRepresentation.Standard));
+
+            map.MapMember(obj => obj.CSharpLegacyId)
+                .SetSerializer(new GuidSerializer(GuidRepresentation.CSharpLegacy));
+
+            map.MapMember(obj => obj.JavaLegacyId)
+                .SetSerializer(new GuidSerializer(GuidRepresentation.JavaLegacy));
+
+            map.MapMember(obj => obj.PythonLegacyId)
+                .SetSerializer(new GuidSerializer(GuidRepresentation.PythonLegacy));
+        });
+
+        BsonClassMap.RegisterClassMap<StandardIdSagaData>(map =>
+        {
+            map.MapIdMember(obj => obj.Id)
+                .SetSerializer(new GuidSerializer(GuidRepresentation.Standard));
+
+            map.MapMember(obj => obj.Revision);
+            map.MapMember(obj => obj.State);
+        });
+
+        BsonClassMap.RegisterClassMap<CSharpLegacyIdSagaData>(map =>
+        {
+            map.MapIdMember(obj => obj.Id)
+                .SetSerializer(new GuidSerializer(GuidRepresentation.Standard));
+
+            map.MapMember(obj => obj.Revision);
+            map.MapMember(obj => obj.State);
+        });
+
+        BsonClassMap.RegisterClassMap<JavaLegacyIdSagaData>(map =>
+        {
+            map.MapIdMember(obj => obj.Id)
+                .SetSerializer(new GuidSerializer(GuidRepresentation.Standard));
+
+            map.MapMember(obj => obj.Revision);
+            map.MapMember(obj => obj.State);
+        });
+        BsonClassMap.RegisterClassMap<PythonLegacyIdSagaData>(map =>
+        {
+            map.MapIdMember(obj => obj.Id)
+                .SetSerializer(new GuidSerializer(GuidRepresentation.Standard));
+
+            map.MapMember(obj => obj.Revision);
+            map.MapMember(obj => obj.State);
+        });
+    }
+
+    protected override void SetUp()
+    {
+        var database = MongoTestHelper.GetMongoDatabase();
+        database.DropCollection(nameof(MyGuidRepresentationSagaData));
+        database.DropCollection(nameof(StandardIdSagaData));
+
+        _sagaStorage = new MongoDbSagaStorage(database, new ConsoleLoggerFactory(colored: false));
+        _sagaStorage.Initialize();
+    }
+
+    [Test]
+    [TestCase(nameof(MyGuidRepresentationSagaData.StandardId))]
+    [TestCase(nameof(MyGuidRepresentationSagaData.CSharpLegacyId))]
+    [TestCase(nameof(MyGuidRepresentationSagaData.JavaLegacyId))]
+    [TestCase(nameof(MyGuidRepresentationSagaData.PythonLegacyId))]
+    public async Task CanFind(string propertyName)
+    {
+        var id = Guid.NewGuid();
+        var expected = new MyGuidRepresentationSagaData
+        {
+            Id = Guid.NewGuid(),
+            StandardId = propertyName == nameof(MyGuidRepresentationSagaData.StandardId) ? id : Guid.NewGuid(),
+            CSharpLegacyId = propertyName == nameof(MyGuidRepresentationSagaData.CSharpLegacyId) ? id : Guid.NewGuid(),
+            JavaLegacyId = propertyName == nameof(MyGuidRepresentationSagaData.JavaLegacyId) ? id : Guid.NewGuid(),
+            PythonLegacyId = propertyName == nameof(MyGuidRepresentationSagaData.PythonLegacyId) ? id : Guid.NewGuid(),
+        };
+        await _sagaStorage.Insert(expected, None);
+
+        var actual = await _sagaStorage.Find(typeof(MyGuidRepresentationSagaData), propertyName, id);
+        Assert.That(actual, Is.Not.Null
+            .And.Property("Id").EqualTo(expected.Id));
+    }
+
+    [Test]
+    [TestCase(nameof(StandardIdSagaData))]
+    [TestCase(nameof(CSharpLegacyIdSagaData))]
+    [TestCase(nameof(JavaLegacyIdSagaData))]
+    [TestCase(nameof(PythonLegacyIdSagaData))]
+    public async Task CanUpdate(string implementation)
+    {
+        var id = Guid.NewGuid();
+        var initial = CreateSagaDataWithState(implementation, id, "Initial");
+        await _sagaStorage.Insert(initial, None);
+
+        await _sagaStorage.Update(CreateSagaDataWithState(implementation, id, "Updated"), None);
+
+        var actual = await _sagaStorage.Find(initial.GetType(), nameof(ISagaData.Id), id);
+        Assert.That(actual, Is.Not.Null
+            .And.InstanceOf(initial.GetType())
+            .With.Property("State").EqualTo("Updated"));
+    }
+
+    private static ISagaDataWithState CreateSagaDataWithState(string implementation, Guid id, string state)
+    {
+        return implementation switch
+        {
+            nameof(StandardIdSagaData) => new StandardIdSagaData { Id = id, State = state },
+            nameof(CSharpLegacyIdSagaData) => new CSharpLegacyIdSagaData { Id = id, State = state },
+            nameof(JavaLegacyIdSagaData) => new JavaLegacyIdSagaData { Id = id, State = state },
+            nameof(PythonLegacyIdSagaData) => new PythonLegacyIdSagaData { Id = id, State = state },
+            _ => throw new ArgumentException("Unknown implementation", nameof(implementation))
+        };
+    }
+
+    class MyGuidRepresentationSagaData : SagaData
+    {
+        public Guid StandardId { get; init; }
+        public Guid CSharpLegacyId { get; init; }
+        public Guid JavaLegacyId { get; init; }
+        public Guid PythonLegacyId { get; init; }
+    }
+
+    interface ISagaDataWithState : ISagaData
+    {
+        string State { get; set; }
+    }
+
+    class StandardIdSagaData : ISagaDataWithState
+    {
+        public Guid Id { get; set; }
+        public int Revision { get; set; }
+        public string State { get; set; }
+    }
+
+    class CSharpLegacyIdSagaData : ISagaDataWithState
+    {
+        public Guid Id { get; set; }
+        public int Revision { get; set; }
+        public string State { get; set; }
+    }
+
+    class JavaLegacyIdSagaData : ISagaDataWithState
+    {
+        public Guid Id { get; set; }
+        public int Revision { get; set; }
+        public string State { get; set; }
+    }
+
+    class PythonLegacyIdSagaData : ISagaDataWithState
+    {
+        public Guid Id { get; set; }
+        public int Revision { get; set; }
+        public string State { get; set; }
+    }
+}

--- a/Rebus.MongoDb.Tests/Bugs/CanFollowGuidRepresentation.cs
+++ b/Rebus.MongoDb.Tests/Bugs/CanFollowGuidRepresentation.cs
@@ -78,6 +78,9 @@ public class CanFollowGuidRepresentation : FixtureBase
         var database = MongoTestHelper.GetMongoDatabase();
         database.DropCollection(nameof(MyGuidRepresentationSagaData));
         database.DropCollection(nameof(StandardIdSagaData));
+        database.DropCollection(nameof(CSharpLegacyIdSagaData));
+        database.DropCollection(nameof(JavaLegacyIdSagaData));
+        database.DropCollection(nameof(PythonLegacyIdSagaData));
 
         _sagaStorage = new MongoDbSagaStorage(database, new ConsoleLoggerFactory(colored: false));
         _sagaStorage.Initialize();

--- a/Rebus.MongoDb.Tests/Bugs/CanFollowGuidRepresentation.cs
+++ b/Rebus.MongoDb.Tests/Bugs/CanFollowGuidRepresentation.cs
@@ -49,7 +49,7 @@ public class CanFollowGuidRepresentation : FixtureBase
         BsonClassMap.RegisterClassMap<CSharpLegacyIdSagaData>(map =>
         {
             map.MapIdMember(obj => obj.Id)
-                .SetSerializer(new GuidSerializer(GuidRepresentation.Standard));
+                .SetSerializer(new GuidSerializer(GuidRepresentation.CSharpLegacy));
 
             map.MapMember(obj => obj.Revision);
             map.MapMember(obj => obj.State);
@@ -58,7 +58,7 @@ public class CanFollowGuidRepresentation : FixtureBase
         BsonClassMap.RegisterClassMap<JavaLegacyIdSagaData>(map =>
         {
             map.MapIdMember(obj => obj.Id)
-                .SetSerializer(new GuidSerializer(GuidRepresentation.Standard));
+                .SetSerializer(new GuidSerializer(GuidRepresentation.JavaLegacy));
 
             map.MapMember(obj => obj.Revision);
             map.MapMember(obj => obj.State);
@@ -66,7 +66,7 @@ public class CanFollowGuidRepresentation : FixtureBase
         BsonClassMap.RegisterClassMap<PythonLegacyIdSagaData>(map =>
         {
             map.MapIdMember(obj => obj.Id)
-                .SetSerializer(new GuidSerializer(GuidRepresentation.Standard));
+                .SetSerializer(new GuidSerializer(GuidRepresentation.PythonLegacy));
 
             map.MapMember(obj => obj.Revision);
             map.MapMember(obj => obj.State);
@@ -123,6 +123,23 @@ public class CanFollowGuidRepresentation : FixtureBase
         Assert.That(actual, Is.Not.Null
             .And.InstanceOf(initial.GetType())
             .With.Property("State").EqualTo("Updated"));
+    }
+
+    [Test]
+    [TestCase(nameof(StandardIdSagaData))]
+    [TestCase(nameof(CSharpLegacyIdSagaData))]
+    [TestCase(nameof(JavaLegacyIdSagaData))]
+    [TestCase(nameof(PythonLegacyIdSagaData))]
+    public async Task CanDelete(string implementation)
+    {
+        var id = Guid.NewGuid();
+        var initial = CreateSagaDataWithState(implementation, id, "Initial");
+        await _sagaStorage.Insert(initial, None);
+
+        await _sagaStorage.Delete(initial);
+
+        var actual = await _sagaStorage.Find(initial.GetType(), nameof(ISagaData.Id), id);
+        Assert.That(actual, Is.Null);
     }
 
     private static ISagaDataWithState CreateSagaDataWithState(string implementation, Guid id, string state)

--- a/Rebus.MongoDb.Tests/MongoTestHelper.cs
+++ b/Rebus.MongoDb.Tests/MongoTestHelper.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver;
 using Rebus.Tests.Contracts;
 
@@ -44,9 +46,9 @@ public class MongoTestHelper
         var url = GetUrl();
         var settings = new MongoDatabaseSettings
         {
-            GuidRepresentation = GuidRepresentation.Standard,
             WriteConcern = WriteConcern.Acknowledged,
         };
+        BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
         return mongoClient.GetDatabase(url.DatabaseName, settings);
     }
 

--- a/Rebus.MongoDb.Tests/MongoTestHelper.cs
+++ b/Rebus.MongoDb.Tests/MongoTestHelper.cs
@@ -11,6 +11,12 @@ public class MongoTestHelper
 {
     public const string TestCategory = "mongodb";
 
+    static MongoTestHelper()
+    {
+        // One-time setup, use Standard Guid representation by default
+        BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
+    }
+
     public static MongoUrl GetUrl()
     {
         var suffix = TestConfig.Suffix;
@@ -48,7 +54,6 @@ public class MongoTestHelper
         {
             WriteConcern = WriteConcern.Acknowledged,
         };
-        BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
         return mongoClient.GetDatabase(url.DatabaseName, settings);
     }
 

--- a/Rebus.MongoDb.Tests/MongoTestHelper.cs
+++ b/Rebus.MongoDb.Tests/MongoTestHelper.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization;
-using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver;
 using Rebus.Tests.Contracts;
 
@@ -46,6 +44,7 @@ public class MongoTestHelper
         var url = GetUrl();
         var settings = new MongoDatabaseSettings
         {
+            GuidRepresentation = GuidRepresentation.Standard,
             WriteConcern = WriteConcern.Acknowledged,
         };
         return mongoClient.GetDatabase(url.DatabaseName, settings);

--- a/Rebus.MongoDb.Tests/MongoTestHelper.cs
+++ b/Rebus.MongoDb.Tests/MongoTestHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using MongoDB.Bson;
 using MongoDB.Driver;
 using Rebus.Tests.Contracts;
 
@@ -44,7 +43,6 @@ public class MongoTestHelper
         var url = GetUrl();
         var settings = new MongoDatabaseSettings
         {
-            GuidRepresentation = GuidRepresentation.Standard,
             WriteConcern = WriteConcern.Acknowledged,
         };
         return mongoClient.GetDatabase(url.DatabaseName, settings);

--- a/Rebus.MongoDb.Tests/MongoTestHelper.cs
+++ b/Rebus.MongoDb.Tests/MongoTestHelper.cs
@@ -11,12 +11,6 @@ public class MongoTestHelper
 {
     public const string TestCategory = "mongodb";
 
-    static MongoTestHelper()
-    {
-        // One-time setup, use Standard Guid representation by default
-        BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
-    }
-
     public static MongoUrl GetUrl()
     {
         var suffix = TestConfig.Suffix;

--- a/Rebus.MongoDb.Tests/PrepareGlobalBsonSerializer.cs
+++ b/Rebus.MongoDb.Tests/PrepareGlobalBsonSerializer.cs
@@ -2,6 +2,7 @@
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
 using NUnit.Framework;
+using Rebus.Sagas;
 
 namespace Rebus.MongoDb.Tests;
 
@@ -12,10 +13,19 @@ public class PrepareGlobalBsonSerializer
     [Description("The MongoDB driver has a global BSON serializer, which we'll prep once and for all here.")]
     public void PrettRidiculousButWeWillDoItAnyway()
     {
-        BsonSerializer.RegisterSerializer(
-            new ObjectSerializer(BsonSerializer.LookupDiscriminatorConvention(typeof(object)),
-                GuidRepresentation.CSharpLegacy, _ => true));
+        BsonSerializer.RegisterSerializer(new ObjectSerializer(_ => true));
 
-        BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.CSharpLegacy));
+        // Default class map for all saga data inheriting from this base class
+        BsonClassMap.RegisterClassMap<SagaData>(map =>
+        {
+            map.MapIdMember(obj => obj.Id).SetSerializer(new GuidSerializer(GuidRepresentation.Standard));
+            map.MapMember(obj => obj.Revision);
+        });
+
+        /*
+         * Default Guid representation to Standard (required for test cases with private saga data which directly
+         * implements ISagaData
+         */
+        BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
     }
 }

--- a/Rebus.MongoDb.Tests/PrepareGlobalBsonSerializer.cs
+++ b/Rebus.MongoDb.Tests/PrepareGlobalBsonSerializer.cs
@@ -1,4 +1,5 @@
-﻿using MongoDB.Bson.Serialization;
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
 using NUnit.Framework;
 
@@ -9,5 +10,12 @@ public class PrepareGlobalBsonSerializer
 {
     [OneTimeSetUp]
     [Description("The MongoDB driver has a global BSON serializer, which we'll prep once and for all here.")]
-    public void PrettRidiculousButWeWillDoItAnyway() => BsonSerializer.RegisterSerializer(new ObjectSerializer(_ => true));
+    public void PrettRidiculousButWeWillDoItAnyway()
+    {
+        BsonSerializer.RegisterSerializer(
+            new ObjectSerializer(BsonSerializer.LookupDiscriminatorConvention(typeof(object)),
+                GuidRepresentation.CSharpLegacy, _ => true));
+
+        BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.CSharpLegacy));
+    }
 }

--- a/Rebus.MongoDb/MongoDb/Sagas/MongoDbSagaStorage.cs
+++ b/Rebus.MongoDb/MongoDb/Sagas/MongoDbSagaStorage.cs
@@ -62,9 +62,13 @@ public class MongoDbSagaStorage : ISagaStorage, IInitializable
     {
         var collection = await GetCollection(sagaDataType);
 
+        var value = propertyValue is Guid guid
+            ? new BsonBinaryData(guid, GuidRepresentation.CSharpLegacy)
+            : BsonValue.Create(propertyValue);
+
         var criteria = propertyName == nameof(ISagaData.Id)
-            ? new BsonDocument { { "_id", BsonValue.Create(propertyValue) } }
-            : new BsonDocument { { propertyName, BsonValue.Create(propertyValue) } };
+            ? new BsonDocument { { "_id", value } }
+            : new BsonDocument { { propertyName, value } };
 
         var result = await collection.Find(criteria).FirstOrDefaultAsync().ConfigureAwait(false);
 

--- a/Rebus.MongoDb/Rebus.MongoDb.csproj
+++ b/Rebus.MongoDb/Rebus.MongoDb.csproj
@@ -3,7 +3,7 @@
 		<OutputType>Library</OutputType>
 		<RootNamespace>Rebus</RootNamespace>
 		<AssemblyName>Rebus.MongoDb</AssemblyName>
-		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;netstandard2.1;net472</TargetFrameworks>
 		<LangVersion>11</LangVersion>
 		<Authors>mookid8000</Authors>
 		<PackageProjectUrl>https://rebus.fm/what-is-rebus/</PackageProjectUrl>

--- a/Rebus.MongoDb/Rebus.MongoDb.csproj
+++ b/Rebus.MongoDb/Rebus.MongoDb.csproj
@@ -24,8 +24,7 @@
 		<None Include="icon.png" Pack="true" PackagePath="" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="mongodb.driver" Version="2.28.0" />
-		<PackageReference Include="MongoDB.Driver.GridFS" Version="2.28.0" />
+		<PackageReference Include="mongodb.driver" Version="3.0.0" />
 		<PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
 		<PackageReference Include="rebus" Version="8.0.1" />
 	</ItemGroup>


### PR DESCRIPTION
In 3.0.0, all of Core has been merged into one, which is why we can drop dependency on `MongoDB.Driver.GridFS`.

`GuidRepresentation` has also been altered, so now to get a default Guid representation behaviour, we must register a global `GuidSerializer` with a selected representation.

Alternatively, a representation must be choosen on a per-field basis using annotations.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
